### PR TITLE
Fix Geometry FormatError

### DIFF
--- a/UIBrowser/App.xaml.cs
+++ b/UIBrowser/App.xaml.cs
@@ -15,6 +15,7 @@ namespace UIBrowser
     {
         public App()
         {
+            Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
             //System.Threading.Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-US");
         }
     }


### PR DESCRIPTION
In some cultures (PC Culture), commas are replaced by slashes, causing errors. The problem can be solved by fixing the program Culture